### PR TITLE
added release drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,20 @@
+name: Release Drafter
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+permissions:
+  contents: read
+
+jobs:
+  release-draft:
+    permissions:
+      pull-requests: write
+      contents: write
+    uses: coopnorge/github-workflow-release-drafter/.github/workflows/release-drafter-go.yaml@v0.1.2


### PR DESCRIPTION
This changes introduces new workflow which creates draft releases automatically, when a PR is create.

[See](https://github.com/coopnorge/engineering-issues/issues/325) for discussion on why this was necessary.

[Docs](https://inventory.internal.coop/docs/default/Component/github-workflow-release-drafter) on how release-drafter works.
