### PR TITLE
chore(package): Upgrade to go 1.25.0

### DIFF
--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/coopnorge/engineering-docker-images/e0/devtools-golang-v1beta1:latest@sha256:94de14da1e51e006147e97efaec7203ba588bdba80d7df4a629960c133b6231b AS golang-devtools
+FROM ghcr.io/coopnorge/engineering-docker-images/e0/devtools-golang-v1beta1:latest@sha256:7455d2add5079245f4239fafbf511f4c0cd0957da90c3e5ec3c6245224819b5f AS golang-devtools
 FROM ghcr.io/coopnorge/engineering-docker-images/e0/techdocs:latest@sha256:82d178ca4f68bee4a73eab9982362220ca3e141f4add3c16ab151b98589c2a27 as techdocs

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coopnorge/go-redis-facade
 
-go 1.23.0
+go 1.25.0
 
 require (
 	github.com/alicebob/miniredis v2.5.0+incompatible


### PR DESCRIPTION
Updates go to version 1.25.0 and runs `go mod tidy`.

Before:
  `go 1.24.0`

After:
  `go 1.25.0`

More details can be found here:
- This PR seeks to address https://github.com/coopnorge/engineering-issues/issues/451
